### PR TITLE
Bug #243821: Beneficiary UI- Landing module not highlighted in the top menu after admin login on Beneficiary app

### DIFF
--- a/src/components/common/admin/Header.tsx
+++ b/src/components/common/admin/Header.tsx
@@ -115,22 +115,29 @@ const HeaderRightSection: React.FC<HeaderRightSectionProps> = ({
 }) => {
 	const location = useLocation();
 
-	const getMenuPath = (label: string): string => {
-		if (label === 'Documents Master')
-			return ADMIN_ROUTES.DOCUMENT_CONFIG;
-		if (label === 'Fields to VC Field Mapping')
-			return ADMIN_ROUTES.FIELD_CONFIG;
-		if (label === 'Fields')
-			return ADMIN_ROUTES.ADD_FIELD;
-		return '';
+	const getMenuPath = (label: string): string | undefined => {
+		if (label === 'Documents Master') return ADMIN_ROUTES.DOCUMENT_CONFIG;
+		if (label === 'Fields to VC Field Mapping') return ADMIN_ROUTES.FIELD_CONFIG;
+		if (label === 'Fields') return ADMIN_ROUTES.ADD_FIELD;
+		return undefined;
 	};
+
+	// Find active label based on current route
+	let activeLabel = menuNames.find((menu) => {
+		const path = getMenuPath(menu.label);
+		return path && location.pathname === path;
+	})?.label;
+
+	// If no match, fallback to "Documents Master"
+	if (!activeLabel) {
+		activeLabel = 'Documents Master';
+	}
 
 	return (
 		<HStack align="center" spacing={6}>
 			{showMenu &&
 				menuNames.map((menu, index) => {
-					const path = getMenuPath(menu.label);
-					const isActive = location.pathname === path;
+					const isActive = menu.label === activeLabel;
 
 					return (
 						<HStack key={menu?.label || index} align="center">

--- a/src/components/common/admin/Header.tsx
+++ b/src/components/common/admin/Header.tsx
@@ -116,11 +116,11 @@ const HeaderRightSection: React.FC<HeaderRightSectionProps> = ({
 	const location = useLocation();
 
 	const getMenuPath = (label: string): string => {
-		if (label === 'Document Configuration')
+		if (label === 'Documents Master')
 			return ADMIN_ROUTES.DOCUMENT_CONFIG;
-		if (label === 'Field Mapping Configuration')
+		if (label === 'Fields to VC Field Mapping')
 			return ADMIN_ROUTES.FIELD_CONFIG;
-		if (label === 'Add Field')
+		if (label === 'Fields')
 			return ADMIN_ROUTES.ADD_FIELD;
 		return '';
 	};

--- a/src/components/common/admin/Header.tsx
+++ b/src/components/common/admin/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Box, HStack, Text, useToast } from '@chakra-ui/react';
 import Logo from '../../../assets/images/logo.png';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -15,7 +15,7 @@ interface MenuItemConfig {
 const ADMIN_ROUTES = {
 	DOCUMENT_CONFIG: '/vcConfig',
 	FIELD_CONFIG: '/fieldConfig',
-	ADD_FIELD:'/fields',
+	ADD_FIELD: '/fields',
 	HOME: '/',
 } as const;
 
@@ -116,22 +116,24 @@ const HeaderRightSection: React.FC<HeaderRightSectionProps> = ({
 	const location = useLocation();
 
 	const getMenuPath = (label: string): string | undefined => {
-		if (label === 'Documents Master') return ADMIN_ROUTES.DOCUMENT_CONFIG;
-		if (label === 'Fields to VC Field Mapping') return ADMIN_ROUTES.FIELD_CONFIG;
+		if (label === 'Document Configuration')
+			return ADMIN_ROUTES.DOCUMENT_CONFIG;
+		if (label === 'Fields to VC Field Mapping')
+			return ADMIN_ROUTES.FIELD_CONFIG;
 		if (label === 'Fields') return ADMIN_ROUTES.ADD_FIELD;
 		return undefined;
 	};
 
-	// Find active label based on current route
-	let activeLabel = menuNames.find((menu) => {
-		const path = getMenuPath(menu.label);
-		return path && location.pathname === path;
-	})?.label;
+	// Optimize with useMemo - only recalculate when location.pathname or menuNames change
+	const activeLabel = useMemo(() => {
+		const foundMenu = menuNames.find((menu) => {
+			const path = getMenuPath(menu.label);
+			return path && location.pathname === path;
+		});
 
-	// If no match, fallback to "Documents Master"
-	if (!activeLabel) {
-		activeLabel = 'Documents Master';
-	}
+		// If no match, fallback to "Documents Master"
+		return foundMenu?.label || 'Documents Master';
+	}, [location.pathname, menuNames]);
 
 	return (
 		<HStack align="center" spacing={6}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for determining and displaying the active menu item in the admin header for a more accurate user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->